### PR TITLE
Experimental: Ampify Fast Checkout Button using `amp-iframe`

### DIFF
--- a/js/src/blocks/checkout-button/scss/common.scss
+++ b/js/src/blocks/checkout-button/scss/common.scss
@@ -27,6 +27,7 @@
   }
 
   fast-checkout-button,
+  .fast-checkout-button,
   .fast-co-button-preview {
     flex-basis: 200px;
     flex-grow: 50;


### PR DESCRIPTION
DO NOT MERGE

---

This PR is an attempt for making the Fast Checkout Button AMP compliant. Instead of rendering the `fast-checkout-button` custom web component and enqueueing a `fast.js` dependency, we're delegating this task to an `amp-iframe`.

Note that the iframe endpoint does not exist yet. For testing purposes, you can upload to your web server the following static HTML page:

```html
<!DOCTYPE html>
<html>
<head>
	<meta charset="utf-8"/>
	<title>Fast Checkout Button</title>
	<meta name="viewport" content="width=device-width"/>
	<script src="https://js.fast.co/fast.js"></script>
	<style type="text/css">html, body { margin: 0; overflow: hidden; }</style>
</head>
<body>
<fast-checkout-button></fast-checkout-button>
<script>
	function initFastCheckoutButton() {
		document.querySelector( 'fast-checkout-button' ).addEventListener( 'click', ( event ) => {
			var params = new URLSearchParams( window.location.search );
			if ( params.get( 'app_id' ) && params.get( 'product_id' ) ) {
				Fast.checkout( {
					appId: params.get( 'app_id' ),
					buttonId: event.target.id,
					products: [
						{
							id: params.get( 'product_id' ),
							quantity: Number( params.get( 'quantity' ) ) || 1,
						},
					],
				} );
			}
		} );
	}
	initFastCheckoutButton();
</script>
</body>
</html>
``` 

Next, set the `Blocks::AMP_IFRAME_ENDPOINT_URL` constant value to the URL of this page.

You can also play around with the AMP Checkout button directly, e.g. in the [AMP Playground](https://playground.amp.dev/). Here's a sample code (remember to update the `src` attribute of the `amp-iframe`):

```html
<!DOCTYPE html>
<html ⚡>
<head>
  <meta charset="utf-8" />
  <title>Fast Checkout Button</title>
  <link rel="canonical" href="self.html" />
  <meta name="viewport" content="width=device-width" />
  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
  <script async src="https://cdn.ampproject.org/v0.js"></script>
  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
</head>
<body>
  <amp-iframe
    layout="fixed-height"
    height="50"
    sandbox="allow-scripts allow-same-origin allow-popups"
    src="[AMP_IFRAME_ENDPOINT_URL]?app_id=[APP_ID]&product_id=[PRODUCT_ID]&quantity=1"
  >
    <span placeholder></span>
  </amp-iframe>
</body>
</html>
```